### PR TITLE
Add setup.py (about issue #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,92 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Others
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+from setuptools import setup, find_packages
+from dnapilib import __version__
+
+setup(name='DNApi',
+      version=__version__,
+      description='De novo adapter prediction (iterative) algorithm for small \
+      RNA sequencing data',
+      author='Junko Tsuji',
+      author_email='junko.tsuji@umassmed.edu',
+      url='https://github.com/jnktsj/DNApi',
+      license='MIT',
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Intended Audience :: Science/Research',
+          'Topic :: Scientific/Engineering :: Bio-Informatics',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+      ],
+      keywords='Adapter Prediction',
+      packages=find_packages(),
+      scripts=[
+          'dnapi.py',
+          'utils/qual_offset.py',
+          'utils/qual_trim.py',
+          'utils/to_fasta.py'
+      ]
+      )


### PR DESCRIPTION
I have installed this package using this `setup.py` file and passed all the tests using example codes. I am not sure whether this package could also support python2, so I only listed python3 in the `setup.py` file. If it is also compatible with python2, I could list python2 later. 
Install this package like this: 
```
python3 setup.py install
# or
pip3 install .
```